### PR TITLE
chore(license): update source code headers + copyright year

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -28,7 +28,7 @@ Please see our [support](SUPPORT.md) documentation for further instructions.
 ## Copyright and License
 
 ```
-Copyright (c) 2022 Target Brands, Inc.
+Copyright 2021 Target Brands, Inc.
 ```
 
-[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[Apache License, Version 2.0](../LICENSE)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,9 +35,7 @@ linters-settings:
   # https://github.com/denis-tingaikin/go-header
   goheader:
     template: |-
-      Copyright (c) {{ YEAR }} Target Brands, Inc. All rights reserved.
-      
-      Use of this source code is governed by the LICENSE file in this repository.
+      SPDX-License-Identifier: Apache-2.0
 
   # https://github.com/client9/misspell
   misspell:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# Copyright (c) 2022 Target Brands, Inc. All rights reserved.
-#
-# Use of this source code is governed by the LICENSE file in this repository.
+# SPDX-License-Identifier: Apache-2.0
 
 ########################################################################
 ##    docker build --no-cache --target certs -t vela-slack:certs .    ##

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2022 Target Brands, Inc.
+   Copyright 2021 Target Brands, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-# Copyright (c) 2022 Target Brands, Inc. All rights reserved.
-#
-# Use of this source code is governed by the LICENSE file in this repository.
+# SPDX-License-Identifier: Apache-2.0
 
 # capture the current date we build the application from
 BUILD_DATE = $(shell date +%Y-%m-%dT%H:%M:%SZ)

--- a/cmd/vela-slack/main.go
+++ b/cmd/vela-slack/main.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 
@@ -48,7 +46,7 @@ func main() {
 	app.Name = "vela-slack"
 	app.HelpName = "vela-slack"
 	app.Usage = "Vela Slack plugin for sending data to a Slack channel"
-	app.Copyright = "Copyright (c) 2022 Target Brands, Inc. All rights reserved."
+	app.Copyright = "Copyright 2021 Target Brands, Inc. All rights reserved."
 	app.Authors = []*cli.Author{
 		{
 			Name:  "Vela Admins",

--- a/cmd/vela-slack/plugin.go
+++ b/cmd/vela-slack/plugin.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/cmd/vela-slack/plugin_test.go
+++ b/cmd/vela-slack/plugin_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
+// SPDX-License-Identifier: Apache-2.0
 
 package version
 


### PR DESCRIPTION
ref: https://github.com/go-vela/community/issues/747

- replaces code file license headers with SPDX header (see https://spdx.dev/ids/#why); this removes copyright + year
- update golangci-lint rule to ensure code file enforcement
- use first commit date for copyright year and updates year in other select places
- format is changed to match "Copyright [yyyy] [name of copyright owner]" as shown here: https://www.apache.org/licenses/LICENSE-2.0.html
