### PR TITLE
fix: Prevent error when using quotation marks in BuildMessage

### DIFF
--- a/cmd/vela-slack/plugin.go
+++ b/cmd/vela-slack/plugin.go
@@ -189,8 +189,8 @@ func (p *Plugin) Exec() error {
 
 func cleanBuildMessage(buildMessage string) string {
 	subject := buildMessage
-	subject = strings.Replace(subject, "\n", "\\n", -1)
-	subject = strings.Replace(subject, "\"", "\\\"", -1)
+	subject = strings.ReplaceAll(subject, "\n", "\\n")
+	subject = strings.ReplaceAll(subject, "\"", "\\\"")
 	return subject
 }
 

--- a/cmd/vela-slack/plugin.go
+++ b/cmd/vela-slack/plugin.go
@@ -191,6 +191,7 @@ func cleanBuildMessage(buildMessage string) string {
 	subject := buildMessage
 	subject = strings.ReplaceAll(subject, "\n", "\\n")
 	subject = strings.ReplaceAll(subject, "\"", "\\\"")
+
 	return subject
 }
 

--- a/cmd/vela-slack/plugin.go
+++ b/cmd/vela-slack/plugin.go
@@ -91,7 +91,7 @@ func (p *Plugin) Exec() error {
 	// clean up newlines that could invalidate JSON
 	// BuildMessage is the only field that can have newlines;
 	// typically when the commit contains a title and body message
-	p.Env.BuildMessage = strings.Replace(p.Env.BuildMessage, "\n", "\\n", -1)
+	p.Env.BuildMessage = cleanBuildMessage(p.Env.BuildMessage)
 
 	// create message struct file Slack
 	msg := slack.WebhookMessage{
@@ -185,6 +185,13 @@ func (p *Plugin) Exec() error {
 	logrus.Info("Plugin finished...")
 
 	return nil
+}
+
+func cleanBuildMessage(buildMessage string) string {
+	subject := buildMessage
+	subject = strings.Replace(subject, "\n", "\\n", -1)
+	subject = strings.Replace(subject, "\"", "\\\"", -1)
+	return subject
 }
 
 // Validate function to validate plugin configuration.

--- a/cmd/vela-slack/plugin_test.go
+++ b/cmd/vela-slack/plugin_test.go
@@ -328,6 +328,29 @@ Newlines`,
 	}
 }
 
+func TestSlack_Plugin_Exec_Quote(t *testing.T) {
+	// setup types
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "ok")
+	}))
+	defer ts.Close()
+
+	p := &Plugin{
+		Webhook: ts.URL,
+		Env: &Env{
+			BuildMessage: `This message has "quotes"`,
+		},
+		Path:       "testdata/slack_attachment.json",
+		WebhookMsg: &slack.WebhookMessage{},
+		Remote:     false,
+	}
+
+	err := p.Exec()
+	if err != nil {
+		t.Errorf("Exec returned err: %v", err)
+	}
+}
+
 func TestSlack_Plugin_Exec_Newline_Embedded(t *testing.T) {
 	// setup types
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
When a PR title or commit summary contains quotation marks, they were not escaped when injected into the JSON attachment. This caused a message like

    unable to unmarshal webhook message: invalid character 't' after object key:value pair

when used inside of a template containing this test:

```json
{
  "text": "*Status*: FAILURE\n*Repo*: {{ .RepositoryName }} | *Branch*: {{ .BuildBranch }} | *Author*: {{ .BuildAuthor }}\n*Build*: {{ .BuildLink }}\n*Message*: {{ .BuildMessage }}"
}
```

This change safens this use case. Other typical fields _shouldn't_ have quotation marks in them, but it might be prudent down the line to cleanse _all_ fields as they are injected into the JSON or provide a method usable inside of the template that escapes correctly.
